### PR TITLE
Enhance train_val_test_split with Flexible Test Dataset Support

### DIFF
--- a/bibmon/_bibmon_tools.py
+++ b/bibmon/_bibmon_tools.py
@@ -115,83 +115,11 @@ def spearmanr_dendrogram(df, figsize = (18,8)):
     plt.show()
 
 ###############################################################################
-
-def train_val_test_split(data, start_train, end_train, 
-                          end_validation, end_test, 
-                          tags_X = None, tags_Y = None):
-    """
-    Separates the data into consecutive portions of 
-    train, validation, and test, returning 3 DataFrames.
-    It can also separate into predictor variables (X) and 
-    predicted variables (Y), which in this case will return 6 DataFrames.
-        
-    Parameters
-    ----------
-    data: pandas.DataFrame
-        Data to be separated.
-    start_train: string
-        Start timestamp of the train portion.
-    end_train: string
-        End timestamp of the train portion.
-    end_validation: string
-        End timestamp of the validation portion.
-    end_test: string
-        End timestamp of the test portion.
-    tags_X: list of strings
-        Variables to be considered in the X set.
-    tags_Y: list of strings
-        Variables to be considered in the Y set.
-    Returns
-    ----------                
-    : pandas.DataFrames
-        Separated data.
-    """               
-    train_data = data.loc[start_train:end_train]
-    validation_data = data.loc[end_train:end_validation].iloc[1:,:]
-    test_data = data.loc[end_validation:end_test].iloc[1:,:]
-
-    if tags_Y is not None:
-
-        if not isinstance(tags_Y, list): tags_Y = [tags_Y]
-        
-        train_data_Y = train_data.loc[:,tags_Y]
-        validation_data_Y = validation_data.loc[:,tags_Y]
-        test_data_Y = test_data.loc[:,tags_Y]
-
-        if tags_X is not None:
-
-            if not isinstance(tags_X, list): tags_X = [tags_X]
-            
-            train_data_X = train_data.loc[:,tags_X]
-            validation_data_X = validation_data.loc[:,tags_X]
-            test_data_X = test_data.loc[:,tags_X]
-
-        else:
-
-            dif = train_data.columns.difference(train_data_Y.columns)
-            train_data_X = train_data[dif]
-            validation_data_X = validation_data[dif]
-            test_data_X = test_data[dif]
-            
-        return (train_data_X, validation_data_X, test_data_X, 
-                train_data_Y, validation_data_Y, test_data_Y)
-            
-    else:
-        
-        if tags_X is not None:
-
-            if not isinstance(tags_X, list): tags_Y = [tags_X]
-            
-            train_data = train_data.loc[:,tags_X]
-            validation_data = validation_data.loc[:,tags_X]
-            test_data = test_data.loc[:,tags_X]           
-            
-        return (train_data, validation_data, test_data)
             
 def train_val_test_split (data, start_train, end_train, 
                           end_validation, end_test,
-                          data_test = None, start_test = None,
-                          tags_X = None, tags_Y = None):
+                          tags_X = None, tags_Y = None,
+                          data_test = None, start_test = None):
     """
     Separates the data into consecutive portions of 
     train, validation, and test, returning 3 DataFrames.
@@ -216,19 +144,28 @@ def train_val_test_split (data, start_train, end_train,
         Variables to be considered in the X set.
     tags_Y: list of strings
         Variables to be considered in the Y set.
+    data_test: pandas.DataFrame, optional
+        Data to be used for test.
+    start_test: string, optional
+        Start timestamp of the validation portion.
     Returns
     ----------                
     : pandas.DataFrames
         Separated data.
-    """               
+    """
+
     train_data = data.loc[start_train:end_train]
-
-    if(data_test):
-        test_data = data_test.loc[start_test:end_test].iloc[1:,:]
-    else:
-        test_data = data.loc[end_validation:end_test].iloc[1:,:]
-
     validation_data = data.loc[end_train:end_validation].iloc[1:,:]
+
+    if data_test is not None and start_test is None:
+        raise ValueError("If 'data_test' is provided, 'start_test' must also be provided.")
+    if start_test is not None and data_test is None:
+        raise ValueError("If 'start_test' is provided, 'data_test' must also be provided.")
+    
+    if data_test is not None:
+        test_data = data_test.loc[start_test:end_test].iloc[1:, :]
+    else:
+        test_data = data.loc[end_validation:end_test].iloc[1:, :]
 
     if tags_Y is not None:
 

--- a/bibmon/_bibmon_tools.py
+++ b/bibmon/_bibmon_tools.py
@@ -188,6 +188,86 @@ def train_val_test_split (data, start_train, end_train,
             
         return (train_data, validation_data, test_data)
             
+def train_val_test_split (data, start_train, end_train, 
+                          end_validation, end_test,
+                          data_test = None, start_test = None,
+                          tags_X = None, tags_Y = None):
+    """
+    Separates the data into consecutive portions of 
+    train, validation, and test, returning 3 DataFrames.
+    It can also separate into predictor variables (X) and 
+    predicted variables (Y), which in this case will return 6 DataFrames.
+        
+    Parameters
+    ----------
+    data: pandas.DataFrame
+        Data to be separated.
+    start_train: string
+        Start timestamp of the train portion.
+    end_train: string
+        End timestamp of the train portion.
+    end_validation: string
+        End timestamp of the validation portion.
+    start_test: string
+        Start timestamp of the validation portion.
+    end_test: string
+        End timestamp of the test portion.
+    tags_X: list of strings
+        Variables to be considered in the X set.
+    tags_Y: list of strings
+        Variables to be considered in the Y set.
+    Returns
+    ----------                
+    : pandas.DataFrames
+        Separated data.
+    """               
+    train_data = data.loc[start_train:end_train]
+
+    if(data_test):
+        test_data = data_test.loc[start_test:end_test].iloc[1:,:]
+    else:
+        test_data = data.loc[end_validation:end_test].iloc[1:,:]
+
+    validation_data = data.loc[end_train:end_validation].iloc[1:,:]
+
+    if tags_Y is not None:
+
+        if not isinstance(tags_Y, list): tags_Y = [tags_Y]
+        
+        train_data_Y = train_data.loc[:,tags_Y]
+        validation_data_Y = validation_data.loc[:,tags_Y]
+        test_data_Y = test_data.loc[:,tags_Y]
+
+        if tags_X is not None:
+
+            if not isinstance(tags_X, list): tags_X = [tags_X]
+            
+            train_data_X = train_data.loc[:,tags_X]
+            validation_data_X = validation_data.loc[:,tags_X]
+            test_data_X = test_data.loc[:,tags_X]
+
+        else:
+
+            dif = train_data.columns.difference(train_data_Y.columns)
+            train_data_X = train_data[dif]
+            validation_data_X = validation_data[dif]
+            test_data_X = test_data[dif]
+            
+        return (train_data_X, validation_data_X, test_data_X, 
+                train_data_Y, validation_data_Y, test_data_Y)
+            
+    else:
+        
+        if tags_X is not None:
+
+            if not isinstance(tags_X, list): tags_Y = [tags_X]
+            
+            train_data = train_data.loc[:,tags_X]
+            validation_data = validation_data.loc[:,tags_X]
+            test_data = test_data.loc[:,tags_X]           
+            
+        return (train_data, validation_data, test_data)
+
 ###############################################################################
 
 def complete_analysis (model, X_train, X_validation, X_test, 

--- a/bibmon/_bibmon_tools.py
+++ b/bibmon/_bibmon_tools.py
@@ -695,7 +695,6 @@ def comparative_table (models, X_train, X_validation, X_test,
     return return_tables
 
 ##############################################################################
-# complete_analysis + comparative_table
 
 def compare_variables_for_regression (data, start_train, end_train, 
                           end_validation, end_test, 
@@ -736,7 +735,6 @@ def compare_variables_for_regression (data, start_train, end_train,
         End timestamp of the test data.
     tags: list of strings
         List of variable names (tags) to be used as targets (Y) in the model.
-    
     model: BibMon model
         Model to be considered in the analysis.
     metrics: list of functions, optional

--- a/bibmon/_bibmon_tools.py
+++ b/bibmon/_bibmon_tools.py
@@ -136,8 +136,6 @@ def train_val_test_split (data, start_train, end_train,
         End timestamp of the train portion.
     end_validation: string
         End timestamp of the validation portion.
-    start_test: string
-        Start timestamp of the validation portion.
     end_test: string
         End timestamp of the test portion.
     tags_X: list of strings
@@ -147,7 +145,7 @@ def train_val_test_split (data, start_train, end_train,
     data_test: pandas.DataFrame, optional
         Data to be used for test.
     start_test: string, optional
-        Start timestamp of the validation portion.
+        Start timestamp of the test portion.
     Returns
     ----------                
     : pandas.DataFrames

--- a/bibmon/_bibmon_tools.py
+++ b/bibmon/_bibmon_tools.py
@@ -116,7 +116,7 @@ def spearmanr_dendrogram(df, figsize = (18,8)):
 
 ###############################################################################
 
-def train_val_test_split (data, start_train, end_train, 
+def train_val_test_split(data, start_train, end_train, 
                           end_validation, end_test, 
                           tags_X = None, tags_Y = None):
     """


### PR DESCRIPTION
## What was changed

Changed function `train_val_test_split` in `_bibmon_tools.py`

-  Added two more optionals parameters `data_test` and `start_test`.


## Objective

Enable the user to train and validate a model with one dataset and test it with another, allowing flexible partitioning for training, validation, and testing phases.

## Importance
The new parameters data_test and start_test improve the function train_val_test_split by allowing the user to train and validate a model with one dataset and test it with another. This flexibility enables testing on data from different distributions or scenarios, enhancing model evaluation. The start_test parameter further allows for precise control over the test set's starting point within the provided test data, making the function more versatile for time-series and other partitioned datasets.

## How to use

```python
import bibmon

(X_train, X_validation, 
 X_test, Y_train, 
 Y_validation, Y_test) = bibmon.train_val_test_split(dataNormalOperation, 
                                                     start_train = start_train,
                                                     end_train = end_train, 
                                                     end_validation = end_validation,
                                                     end_test = end_test,
                                                     tags_Y = ['T-TPT'],
                                                     data_test = dataFault,
                                                     start_test = start_test)
```