### PR TITLE
Add new functionality to calculate timestamps for dataframe splits based on user-defined percentages

### DIFF
--- a/bibmon/__init__.py
+++ b/bibmon/__init__.py
@@ -5,11 +5,11 @@ from ._sbm import SBM
 from ._sklearn_regressor import sklearnRegressor
 from ._preprocess import PreProcess
 from ._load_data import load_tennessee_eastman, load_real_data
-from ._bibmon_tools import train_val_test_split, complete_analysis, comparative_table, spearmanr_dendrogram, create_df_with_dates, create_df_with_noise, align_dfs_by_rows
+from ._bibmon_tools import train_val_test_split, complete_analysis, comparative_table, spearmanr_dendrogram, create_df_with_dates, create_df_with_noise, align_dfs_by_rows, calculate_timestamps
 
 __all__ = ['Autoencoder','PCA','ESN','SBM',
 	   'sklearnRegressor', 'PreProcess',
            'load_tennessee_eastman', 'load_real_data', 
            'train_val_test_split', 'complete_analysis', 'comparative_table',
 	       'spearmanr_dendrogram', 'create_df_with_dates',
-           'create_df_with_noise', 'align_dfs_by_rows']
+           'create_df_with_noise', 'align_dfs_by_rows', 'calculate_timestamps']


### PR DESCRIPTION
This PR introduces a new function, `calculate_timestamps`, which allows splitting a dataframe into train, validation, and test sets based on percentage inputs. Additionally, the function supports optional preservation of continuous periods, determined by a time tolerance parameter.

### Key Features:
- **Percentage-based splits**: The function takes percentages for train, validation, and test sets and returns the corresponding timestamps for splitting the data.
- **Period preservation**: When the `preserve_periods` option is enabled, the function ensures that the splits occur at the end of continuous periods, preventing data from being split in the middle of a period.
- **Time tolerance**: The function includes a `time_tolerance` parameter, which defines the minimum gap between observations to be considered as the start of a new period.

### Unit Tests:
- Added comprehensive unit tests to cover:
  - Period preservation behavior.
  - Validation of input percentages (ensuring they sum to 1).
  - Handling of dataframes without a `DatetimeIndex`.
  - Small `time_tolerance` cases to ensure gaps are correctly respected.